### PR TITLE
Fix Quarkus SignService signature

### DIFF
--- a/quarkus/src/main/java/tech/best/SignService.java
+++ b/quarkus/src/main/java/tech/best/SignService.java
@@ -8,6 +8,10 @@ import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
 import java.util.UUID;
 
 @ApplicationScoped
@@ -22,11 +26,21 @@ public class SignService {
   @Incoming("unsigned-messages")
   public void handleMessage(UnsignedMessage messageToSign) {
     // Warning! Never use this in production. Use a library and use a proper and modern hashing algorithm
-    String signature = "AAAAA";
+    String signature = md5Hex(messageToSign.text());
 
     LOG.info("Message signed. [messageId={}, text={}]", messageToSign.messageId(), messageToSign.text());
 
     emitter.send(new SignedMessage(messageToSign.messageId(), signature));
+  }
+
+  private String md5Hex(String text) {
+    try {
+      MessageDigest md = MessageDigest.getInstance("MD5");
+      byte[] digest = md.digest(text.getBytes(StandardCharsets.UTF_8));
+      return HexFormat.of().formatHex(digest);
+    } catch (NoSuchAlgorithmException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   public record UnsignedMessage(UUID messageId, String text) {


### PR DESCRIPTION
## Summary
- compute actual MD5 signature in Quarkus `SignService`

## Testing
- `./gradlew :quarkus:test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68623623e57c8328be958a35fac2950e